### PR TITLE
busybox: add /etc/services

### DIFF
--- a/glibc/Dockerfile.builder
+++ b/glibc/Dockerfile.builder
@@ -11,6 +11,7 @@ RUN set -x \
     && set -- \
         /etc/ssl/certs/ca-certificates.crt \
         /usr/share/zoneinfo \
+        /etc/services \
         /lib/"$(gcc -print-multiarch)"/libpthread.so.* \
     && while [ "$#" -gt 0  ]; do \
         f="$1"; shift; \

--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -11,6 +11,7 @@ RUN set -x \
     && set -- \
         /etc/ssl/certs/ca-certificates.crt \
         /usr/share/zoneinfo \
+        /etc/services \
     && while [ "$#" -gt 0  ]; do \
         f="$1"; shift; \
         fn="$(basename "$f")"; \ 


### PR DESCRIPTION
Otherwise, resolving addresses that include named ports (e.g.
code.i3wm.org:git instead of code.i3wm.org:9418) won’t work.