### PR TITLE
Add /etc/nsswistch.conf

### DIFF
--- a/glibc/Dockerfile
+++ b/glibc/Dockerfile
@@ -10,6 +10,7 @@ RUN \
 RUN set -x \
     && mkdir -p rootfs/lib \
     && set -- \
+        /etc/nsswitch.conf \
         /etc/ssl/certs/ca-certificates.crt \
         /usr/share/zoneinfo \
         /etc/services \

--- a/uclibc/Dockerfile
+++ b/uclibc/Dockerfile
@@ -10,6 +10,7 @@ RUN \
 RUN set -x \
     && mkdir -p rootfs/lib \
     && set -- \
+        /etc/nsswitch.conf \
         /etc/ssl/certs/ca-certificates.crt \
         /usr/share/zoneinfo \
         /etc/services \


### PR DESCRIPTION
Add `/etc/nsswitch.conf` to allow netgo to read from `/etc/hosts`.

Closes: https://github.com/prometheus/blackbox_exporter/issues/366

Signed-off-by: Ben Kochie <superq@gmail.com>