### PR TITLE
Use remote docker for builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,28 @@
 ---
-version: 2
+version: 2.1
 
 jobs:
   build:
-    machine:
-      # Use an image with kernel 4.8+, which supports the binfmt_misc `F`
-      # flag required for cross-building docker images without adding qemu
-      # to the image itself.
-      # https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
-
-      # Available images are listed here:
-      # https://circleci.com/docs/2.0/configuration-reference/#machine
-      image: circleci/classic:201808-01
+    docker:
+    - image: circleci/golang:latest
 
     steps:
     - checkout
+    - setup_remote_docker
     - run: docker info
+    - run: uname -a
       # Register binfmt_misc targets for cross-building
     - run: docker run --privileged linuxkit/binfmt:v0.6
     - run: make
     - run: docker images
 
   build_master:
-    machine:
-      image: circleci/classic:201808-01
+    docker:
+    - image: circleci/golang:latest
 
     steps:
     - checkout
+    - setup_remote_docker
     - run: docker info
     - run: docker run --privileged linuxkit/binfmt:v0.6
     - run: make SUFFIX=


### PR DESCRIPTION
Use CircleCI remote docker for builds rather than machine mode.

Signed-off-by: Ben Kochie <superq@gmail.com>