### PR TITLE
Change image naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,21 +21,24 @@ all: build
 
 build:
 	@./build.sh "$(REPOSITORY)/$(NAME)" "" "$(SUFFIX)" $(VERSIONS)
-	@./build.sh "$(REPOSITORY)/$(NAME)-arm32v7-linux" "arm32v7/" "$(SUFFIX)" $(VERSIONS)
-	@./build.sh "$(REPOSITORY)/$(NAME)-arm64v8-linux" "arm64v8/" "$(SUFFIX)" $(VERSIONS)
+	@./build.sh "$(REPOSITORY)/$(NAME)-amd64-linux" "" "$(SUFFIX)" $(VERSIONS)
+	@./build.sh "$(REPOSITORY)/$(NAME)-armv7-linux" "arm32v7/" "$(SUFFIX)" $(VERSIONS)
+	@./build.sh "$(REPOSITORY)/$(NAME)-arm64-linux" "arm64v8/" "$(SUFFIX)" $(VERSIONS)
 	# uclibc doens't support ppc64le
 	@./build.sh "$(REPOSITORY)/$(NAME)-ppc64le-linux" "ppc64le/" "$(SUFFIX)" glibc
 
 tag:
 	docker tag "$(REPOSITORY)/$(NAME):uclibc" "$(REPOSITORY)/$(NAME):latest"
-	docker tag "$(REPOSITORY)/$(NAME)-arm32v7-linux:uclibc" "$(REPOSITORY)/$(NAME)-arm32v7-linux:latest"
-	docker tag "$(REPOSITORY)/$(NAME)-arm64v8-linux:uclibc" "$(REPOSITORY)/$(NAME)-arm64v8-linux:latest"
+	docker tag "$(REPOSITORY)/$(NAME)-amd64-linux:uclibc" "$(REPOSITORY)/$(NAME)-amd64-linux:latest"
+	docker tag "$(REPOSITORY)/$(NAME)-armv7-linux:uclibc" "$(REPOSITORY)/$(NAME)-armv7-linux:latest"
+	docker tag "$(REPOSITORY)/$(NAME)-arm64-linux:uclibc" "$(REPOSITORY)/$(NAME)-arm64-linux:latest"
 	docker tag "$(REPOSITORY)/$(NAME)-ppc64le-linux:glibc" "$(REPOSITORY)/$(NAME)-ppc64le-linux:latest"
 
 push:
 	@./push.sh "$(REPOSITORY)/$(NAME)" "" "$(SUFFIX)" $(VERSIONS)
-	@./push.sh "$(REPOSITORY)/$(NAME)-arm32v7-linux" "arm32v7/" "$(SUFFIX)" $(VERSIONS)
-	@./push.sh "$(REPOSITORY)/$(NAME)-arm64v8-linux" "arm64v8/" "$(SUFFIX)" $(VERSIONS)
+	@./push.sh "$(REPOSITORY)/$(NAME)-amd64-linux" "" "$(SUFFIX)" $(VERSIONS)
+	@./push.sh "$(REPOSITORY)/$(NAME)-armv7-linux" "arm32v7/" "$(SUFFIX)" $(VERSIONS)
+	@./push.sh "$(REPOSITORY)/$(NAME)-arm64-linux" "arm64v8/" "$(SUFFIX)" $(VERSIONS)
 	# uclibc doens't support ppc64le
 	@./push.sh "$(REPOSITORY)/$(NAME)-ppc64le-linux" "ppc64le/" "$(SUFFIX)" glibc
 


### PR DESCRIPTION
In https://github.com/prometheus/prometheus/pull/5031#issuecomment-451649696 agreement was to change the non arm64 naming to `${GOARCH}-${GOOS}`

This also requires to change the created docker hub / quay repositories and a new `busybox-amd64-linux` repository

//cc @discordianfish 