### PR TITLE
Rewrote cross-arch support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
     - run: make tag SUFFIX=
     - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
     - run: make push
+    - run: make manifest SUFFIX=
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -20,23 +20,47 @@ VERSIONS   ?= uclibc glibc
 all: build
 
 build:
-	@./build.sh "$(REPOSITORY)/$(NAME)" "" "$(SUFFIX)" $(VERSIONS)
-	@./build.sh "$(REPOSITORY)/$(NAME)-arm32v7-linux" "arm32v7/" "$(SUFFIX)" $(VERSIONS)
-	@./build.sh "$(REPOSITORY)/$(NAME)-arm64v8-linux" "arm64v8/" "$(SUFFIX)" $(VERSIONS)
+	@./build.sh "$(REPOSITORY)/$(NAME)-linux-amd64" "" "$(SUFFIX)" $(VERSIONS)
+	@./build.sh "$(REPOSITORY)/$(NAME)-linux-armv7" "arm32v7/" "$(SUFFIX)" $(VERSIONS)
+	@./build.sh "$(REPOSITORY)/$(NAME)-linux-armv8" "arm64v8/" "$(SUFFIX)" $(VERSIONS)
 	# uclibc doens't support ppc64le
-	@./build.sh "$(REPOSITORY)/$(NAME)-ppc64le-linux" "ppc64le/" "$(SUFFIX)" glibc
+	@./build.sh "$(REPOSITORY)/$(NAME)-linux-ppc64le" "ppc64le/" "$(SUFFIX)" glibc
 
 tag:
-	docker tag "$(REPOSITORY)/$(NAME):uclibc" "$(REPOSITORY)/$(NAME):latest"
-	docker tag "$(REPOSITORY)/$(NAME)-arm32v7-linux:uclibc" "$(REPOSITORY)/$(NAME)-arm32v7-linux:latest"
-	docker tag "$(REPOSITORY)/$(NAME)-arm64v8-linux:uclibc" "$(REPOSITORY)/$(NAME)-arm64v8-linux:latest"
-	docker tag "$(REPOSITORY)/$(NAME)-ppc64le-linux:glibc" "$(REPOSITORY)/$(NAME)-ppc64le-linux:latest"
+	docker tag "$(REPOSITORY)/$(NAME)-linux-amd64:uclibc" "$(REPOSITORY)/$(NAME)-linux-amd64:latest"
+	docker tag "$(REPOSITORY)/$(NAME)-linux-armv7:uclibc" "$(REPOSITORY)/$(NAME)-linux-armv7:latest"
+	docker tag "$(REPOSITORY)/$(NAME)-linux-armv8:uclibc" "$(REPOSITORY)/$(NAME)-linux-armv8:latest"
+	docker tag "$(REPOSITORY)/$(NAME)-linux-ppc64le:glibc" "$(REPOSITORY)/$(NAME)-linux-ppc64le:latest"
+
+manifest:
+	# Manifest for "ulibc"
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(REPOSITORY)/$(NAME):uclibc" \
+		"$(REPOSITORY)/$(NAME)-linux-amd64:uclibc" \
+		"$(REPOSITORY)/$(NAME)-linux-armv7:uclibc" \
+		"$(REPOSITORY)/$(NAME)-linux-armv8:uclibc"
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(REPOSITORY)/$(NAME):uclibc"
+
+	# Manifest for "glibc"
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(REPOSITORY)/$(NAME):glibc" \
+		"$(REPOSITORY)/$(NAME)-linux-amd64:glibc" \
+		"$(REPOSITORY)/$(NAME)-linux-armv7:glibc" \
+		"$(REPOSITORY)/$(NAME)-linux-armv8:glibc" \
+		"$(REPOSITORY)/$(NAME)-linux-ppc64le:glibc" \
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(REPOSITORY)/$(NAME):glibc"
+
+	# Manifest for "latest"
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create -a "$(REPOSITORY)/$(NAME):latest" \
+		"$(REPOSITORY)/$(NAME)-linux-amd64:latest" \
+		"$(REPOSITORY)/$(NAME)-linux-armv7:latest" \
+		"$(REPOSITORY)/$(NAME)-linux-armv8:latest" \
+		"$(REPOSITORY)/$(NAME)-linux-ppc64le:latest" \
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(REPOSITORY)/$(NAME):latest"
 
 push:
-	@./push.sh "$(REPOSITORY)/$(NAME)" "" "$(SUFFIX)" $(VERSIONS)
-	@./push.sh "$(REPOSITORY)/$(NAME)-arm32v7-linux" "arm32v7/" "$(SUFFIX)" $(VERSIONS)
-	@./push.sh "$(REPOSITORY)/$(NAME)-arm64v8-linux" "arm64v8/" "$(SUFFIX)" $(VERSIONS)
+	@./push.sh "$(REPOSITORY)/$(NAME)-linux-amd64" "" "$(SUFFIX)" $(VERSIONS)
+	@./push.sh "$(REPOSITORY)/$(NAME)-linux-armv7" "arm32v7/" "$(SUFFIX)" $(VERSIONS)
+	@./push.sh "$(REPOSITORY)/$(NAME)-linux-armv8" "arm64v8/" "$(SUFFIX)" $(VERSIONS)
 	# uclibc doens't support ppc64le
-	@./push.sh "$(REPOSITORY)/$(NAME)-ppc64le-linux" "ppc64le/" "$(SUFFIX)" glibc
+	@./push.sh "$(REPOSITORY)/$(NAME)-linux-ppc64le" "ppc64le/" "$(SUFFIX)" glibc
 
 .PHONY: build all tag push


### PR DESCRIPTION
Publish image archs to respective repositories named after `GOOS` and `GOARCH`

Publish a manifest to `prom/busybox` so pulling `docker pull prom/busybox:latest` still works and automatically resolves the correct arch.