### PR TITLE
Docker image for s390x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     - run: docker info
     - run: uname -a
       # Register binfmt_misc targets for cross-building
-    - run: docker run --privileged linuxkit/binfmt:v0.6
+    - run: docker run --privileged linuxkit/binfmt:v0.7
     - run: make
     - run: docker images
 
@@ -28,7 +28,7 @@ jobs:
         version: 18.06.0-ce
     - run: apk add make bash git
     - run: docker info
-    - run: docker run --privileged linuxkit/binfmt:v0.6
+    - run: docker run --privileged linuxkit/binfmt:v0.7
     - run: make SUFFIX=
     - run: docker images
     - run: make tag SUFFIX=

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ build:
 	@./build.sh "$(REPOSITORY)/$(NAME)-linux-amd64" "" "$(SUFFIX)" $(VERSIONS)
 	@./build.sh "$(REPOSITORY)/$(NAME)-linux-armv7" "arm32v7/" "$(SUFFIX)" $(VERSIONS)
 	@./build.sh "$(REPOSITORY)/$(NAME)-linux-arm64" "arm64v8/" "$(SUFFIX)" $(VERSIONS)
-	# uclibc doens't support ppc64le
+	# uclibc doens't support ppc64le, s390x
 	@./build.sh "$(REPOSITORY)/$(NAME)-linux-ppc64le" "ppc64le/" "$(SUFFIX)" glibc
+	@./build.sh "$(REPOSITORY)/$(NAME)-linux-s390x" "s390x/" "$(SUFFIX)" glibc
 
 .PHONY: tag
 tag:
@@ -34,6 +35,7 @@ tag:
 	docker tag "$(REPOSITORY)/$(NAME)-linux-armv7:uclibc" "$(REPOSITORY)/$(NAME)-linux-armv7:latest"
 	docker tag "$(REPOSITORY)/$(NAME)-linux-arm64:uclibc" "$(REPOSITORY)/$(NAME)-linux-arm64:latest"
 	docker tag "$(REPOSITORY)/$(NAME)-linux-ppc64le:glibc" "$(REPOSITORY)/$(NAME)-linux-ppc64le:latest"
+	docker tag "$(REPOSITORY)/$(NAME)-linux-s390x::glibc" "$(REPOSITORY)/$(NAME)-linux-s390x:latest"
 
 .PHONY: manifest
 manifest:
@@ -49,7 +51,8 @@ manifest:
 		"$(REPOSITORY)/$(NAME)-linux-amd64:glibc" \
 		"$(REPOSITORY)/$(NAME)-linux-armv7:glibc" \
 		"$(REPOSITORY)/$(NAME)-linux-arm64:glibc" \
-		"$(REPOSITORY)/$(NAME)-linux-ppc64le:glibc"
+		"$(REPOSITORY)/$(NAME)-linux-ppc64le:glibc" \
+		"$(REPOSITORY)/$(NAME)-linux-s390x:glibc"
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(REPOSITORY)/$(NAME):glibc"
 
 	# Manifest for "latest"
@@ -57,7 +60,8 @@ manifest:
 		"$(REPOSITORY)/$(NAME)-linux-amd64:latest" \
 		"$(REPOSITORY)/$(NAME)-linux-armv7:latest" \
 		"$(REPOSITORY)/$(NAME)-linux-arm64:latest" \
-		"$(REPOSITORY)/$(NAME)-linux-ppc64le:latest"
+		"$(REPOSITORY)/$(NAME)-linux-ppc64le:latest" \
+		"$(REPOSITORY)/$(NAME)-linux-s390x:latest"
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push "$(REPOSITORY)/$(NAME):latest"
 
 .PHONY: push
@@ -65,5 +69,6 @@ push:
 	@./push.sh "$(REPOSITORY)/$(NAME)-linux-amd64" "" "$(SUFFIX)" $(VERSIONS)
 	@./push.sh "$(REPOSITORY)/$(NAME)-linux-armv7" "arm32v7/" "$(SUFFIX)" $(VERSIONS)
 	@./push.sh "$(REPOSITORY)/$(NAME)-linux-arm64" "arm64v8/" "$(SUFFIX)" $(VERSIONS)
-	# uclibc doens't support ppc64le
+	# uclibc doens't support ppc64le, s390x
 	@./push.sh "$(REPOSITORY)/$(NAME)-linux-ppc64le" "ppc64le/" "$(SUFFIX)" glibc
+	@./push.sh "$(REPOSITORY)/$(NAME)-linux-s390x" "s390x/" "$(SUFFIX)" glibc


### PR DESCRIPTION
We are trying to add s390x support to Prometheus docker images

Added s390x support to busybox docker image, As this image is required for adding support to build  **Docker images of Prometheus components** for s390x architecture.

Please review changes.