### PR TITLE
Fix riscv64 latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ tag:
 	docker tag "$(REPOSITORY)/$(NAME)-linux-armv7:uclibc" "$(REPOSITORY)/$(NAME)-linux-armv7:latest"
 	docker tag "$(REPOSITORY)/$(NAME)-linux-arm64:uclibc" "$(REPOSITORY)/$(NAME)-linux-arm64:latest"
 	docker tag "$(REPOSITORY)/$(NAME)-linux-ppc64le:glibc" "$(REPOSITORY)/$(NAME)-linux-ppc64le:latest"
-	docker tag "$(REPOSITORY)/$(NAME)-linux-riscv64:glibc" "$(REPOSITORY)/$(NAME)-linux-riscv64:latest"
+	docker tag "$(REPOSITORY)/$(NAME)-linux-riscv64:uclibc" "$(REPOSITORY)/$(NAME)-linux-riscv64:latest"
 	docker tag "$(REPOSITORY)/$(NAME)-linux-s390x:glibc" "$(REPOSITORY)/$(NAME)-linux-s390x:latest"
 
 .PHONY: manifest


### PR DESCRIPTION
risv64 only supports uclibc, use this for latest.