### PR TITLE
add os-release files to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following files are added (taken from Debian) to fix some common issues:
 - `/etc/ssl/certs/ca-certificates.crt` : for HTTPS support
 - `/usr/share/zoneinfo` : for timezones
 - `/etc/services` : for named ports resolution
+- `/etc/os-release` and `/usr/lib/os-release` : for base OS identification
 
 ### prom/busybox:glibc : glibc
 
@@ -25,6 +26,7 @@ The following files are added (taken from Debian) to fix some common issues:
 - `/etc/ssl/certs/ca-certificates.crt` : for HTTPS support
 - `/usr/share/zoneinfo` : for timezones
 - `/etc/services` : for named ports resolution
+- `/etc/os-release` and `/usr/lib/os-release` : for base OS identification
 - `/lib/x86_64-linux-gnu/libpthread.so.0` : common required lib for project binaries that cannot be statically built.
 
 ## Build Docker images locally

--- a/glibc/Dockerfile
+++ b/glibc/Dockerfile
@@ -5,7 +5,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \
-      base-files \
       ca-certificates \
       gcc \
       netbase \
@@ -18,8 +17,6 @@ RUN set -x \
         /etc/ssl/certs/ca-certificates.crt \
         /usr/share/zoneinfo \
         /etc/services \
-        /etc/os-release \
-        /usr/lib/os-release \
         /lib/"$(gcc -print-multiarch)"/libpthread.so.* \
     && while [ "$#" -gt 0  ]; do \
         f="$1"; shift; \
@@ -33,6 +30,22 @@ RUN set -x \
             && cp -av "$f" "rootfs/${f#/}"; \
         fi; \
     done
+
+ARG CODENAME="bookworm"
+ARG VERSION="12"
+ARG OS_RELEASE_FILE=/rootfs/usr/lib/os-release
+
+RUN mkdir -p /rootfs/usr/lib && \
+    echo 'PRETTY_NAME="Prometheus Busybox"' > ${OS_RELEASE_FILE} && \
+    echo 'NAME="Debian GNU/Linux"' >> ${OS_RELEASE_FILE} && \
+    echo 'ID="debian"' >> ${OS_RELEASE_FILE} && \
+    echo 'VERSION_ID="'${VERSION}'"' >> ${OS_RELEASE_FILE} && \
+    echo 'VERSION="Debian GNU/Linux '${VERSION}' ('${CODENAME}')"' >> ${OS_RELEASE_FILE} && \
+    echo 'HOME_URL="https://github.com/prometheus/busybox"' >> ${OS_RELEASE_FILE} && \
+    echo 'SUPPORT_URL="https://github.com/prometheus/busybox/blob/master/README.md"' >> ${OS_RELEASE_FILE} && \
+    echo 'BUG_REPORT_URL="https://github.com/prometheus/busybox/issues/new"' >> ${OS_RELEASE_FILE}
+
+RUN ln -s /usr/lib/os-release /rootfs/etc/os-release
 
 FROM        ${ARCH}busybox:glibc
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>

--- a/glibc/Dockerfile
+++ b/glibc/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \
+      base-files \
       ca-certificates \
       gcc \
       netbase \
@@ -17,6 +18,8 @@ RUN set -x \
         /etc/ssl/certs/ca-certificates.crt \
         /usr/share/zoneinfo \
         /etc/services \
+        /etc/os-release \
+        /usr/lib/os-release \
         /lib/"$(gcc -print-multiarch)"/libpthread.so.* \
     && while [ "$#" -gt 0  ]; do \
         f="$1"; shift; \

--- a/uclibc/Dockerfile
+++ b/uclibc/Dockerfile
@@ -5,7 +5,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \
-      base-files \
       ca-certificates \
       gcc \
       netbase \
@@ -18,8 +17,6 @@ RUN set -x \
         /etc/ssl/certs/ca-certificates.crt \
         /usr/share/zoneinfo \
         /etc/services \
-        /etc/os-release \
-        /usr/lib/os-release \
     && while [ "$#" -gt 0  ]; do \
         f="$1"; shift; \
         fn="$(basename "$f")"; \
@@ -32,6 +29,22 @@ RUN set -x \
             && cp -av "$f" "rootfs/${f#/}"; \
         fi; \
     done
+
+ARG CODENAME="bookworm"
+ARG VERSION="12"
+ARG OS_RELEASE_FILE=/rootfs/usr/lib/os-release
+
+RUN mkdir -p /rootfs/usr/lib && \
+    echo 'PRETTY_NAME="Prometheus Busybox"' > ${OS_RELEASE_FILE} && \
+    echo 'NAME="Debian GNU/Linux"' >> ${OS_RELEASE_FILE} && \
+    echo 'ID="debian"' >> ${OS_RELEASE_FILE} && \
+    echo 'VERSION_ID="'${VERSION}'"' >> ${OS_RELEASE_FILE} && \
+    echo 'VERSION="Debian GNU/Linux '${VERSION}' ('${CODENAME}')"' >> ${OS_RELEASE_FILE} && \
+    echo 'HOME_URL="https://github.com/prometheus/busybox"' >> ${OS_RELEASE_FILE} && \
+    echo 'SUPPORT_URL="https://github.com/prometheus/busybox/blob/master/README.md"' >> ${OS_RELEASE_FILE} && \
+    echo 'BUG_REPORT_URL="https://github.com/prometheus/busybox/issues/new"' >> ${OS_RELEASE_FILE}
+
+RUN ln -s /usr/lib/os-release /rootfs/etc/os-release
 
 FROM        ${ARCH}busybox:uclibc
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>

--- a/uclibc/Dockerfile
+++ b/uclibc/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
     apt-get update && apt-get install -y --no-install-recommends \
+      base-files \
       ca-certificates \
       gcc \
       netbase \
@@ -17,6 +18,8 @@ RUN set -x \
         /etc/ssl/certs/ca-certificates.crt \
         /usr/share/zoneinfo \
         /etc/services \
+        /etc/os-release \
+        /usr/lib/os-release \
     && while [ "$#" -gt 0  ]; do \
         f="$1"; shift; \
         fn="$(basename "$f")"; \


### PR DESCRIPTION
It would be helpful for image scanners to have `/etc/os-release` (symlinked to `/usr/lib/os-release`) included in these images. Right now when running `prometheus/node-exporter` in my cluster, the background image scanners are constantly complaining on every sweep that the OS source of the container can not be detected.

The one file is 267 bytes (plus the symlink) so it does not have a meaningful impact on image size.

fyi @SuperQ @sdurrheimer 