### PR TITLE
Fix broken docker build.sh and circleci pipeline issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,5 +18,5 @@ set -e
 source vars.sh
 
 for version in "${versions[@]}"; do
-  docker build --build-arg ARCH="${ARCH}" --build-arg TAG="${TAG}" --pull -t "${IMAGE_NAME}:${version}${SUFFIX}" "${version}"
+  docker build --platform "${PLATFORM}" --build-arg ARCH="${ARCH}" --build-arg TAG="${TAG}" --pull -t "${IMAGE_NAME}:${version}${SUFFIX}" "${version}"
 done

--- a/vars.sh
+++ b/vars.sh
@@ -16,16 +16,32 @@
 [ "$#" -lt 3 ] && echo "Missing args: $0 {IMAGE_NAME} {ARCH} {SUFFIX} {VERSIONS}" && exit 2;
 
 IMAGE_NAME="$1"; shift;
-ARCH="$1"; shift;
+INPUT_ARCH="$1"; shift;
 SUFFIX="$1"; shift;
 TAG="bookworm-slim"
-if [[ "${ARCH}" == "riscv64" ]]; then
-    TAG="sid-slim"
-fi
+PLATFORM="linux/amd64"
 
-if [[ -n "${ARCH}" ]]; then
-  ARCH="${ARCH}/"
-fi
+case "${INPUT_ARCH}" in
+    arm32v7)
+        PLATFORM="linux/arm/v7"
+        ;;
+    arm64v8)
+        PLATFORM="linux/arm64"
+        ;;
+    riscv64)
+        PLATFORM="linux/riscv64"
+        TAG="sid-slim"
+        ;;
+    ppc64le)
+        PLATFORM="linux/ppc64le"
+        ;;
+    s390x)
+        PLATFORM="linux/s390x"
+        ;;
+esac
+
+# We use official images with --platform, so no prefix needed
+ARCH=""
 
 versions=( "$@" )
 if [[ "${#versions[@]}" -eq 0 ]]; then


### PR DESCRIPTION
@SuperQ 

## Description

This PR fixes modernizes the build system to use Docker's `--platform` flag for better cross-compilation support and fixes CI build failures. This originally was included as part of https://github.com/prometheus/busybox/pull/66.

## Changes

*   **Build System Fixes**:
    *   Updated `vars.sh` and `build.sh` to use the standard Docker `--platform` flag (e.g., `linux/arm/v7`) instead of deprecated architecture-prefixed images (e.g., `arm32v7/debian`).
    *   This resolves `no match for platform in manifest` errors encountered during cross-compilation.

## Motivation

The build system updates were necessary to fix broken cross-compilation on modern Docker environments.